### PR TITLE
Fix invalid mode in docker-compose.yml files

### DIFF
--- a/_docs_integrate/examples/docker-compose-with-existing-mongodb.yml
+++ b/_docs_integrate/examples/docker-compose-with-existing-mongodb.yml
@@ -9,6 +9,6 @@ services:
     ports:
       - <exposed-port>:80 # define the port the connector should listen to on the host
     volumes:
-      - <path-to-config-file>/config.json:/config.json:RO
+      - <path-to-config-file>/config.json:/config.json:ro
     #   - </folder/of/your/choice>:/usr/app/logs # select an existing directory of your choice where your log files should be saved
     restart: always

--- a/_docs_integrate/examples/docker-compose-with-mongodb.yml
+++ b/_docs_integrate/examples/docker-compose-with-mongodb.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - <exposed-port>:80 # define the port the connector should listen to on the host
     volumes:
-      - <path-to-config-file>/config.json:/config.json:RO
+      - <path-to-config-file>/config.json:/config.json:ro
     #   - </folder/of/your/choice>:/usr/app/logs # select an existing directory of your choice where your log files should be saved
     depends_on:
       - mongodb


### PR DESCRIPTION
While running the example docker-compose YAML file I got the following error with version `1.28.6` on a Linux distribution:

```
Cannot create container for service enmeshed-connector: invalid mode: RO
```

Changing `RO` to `ro` fixes this error for me. See also https://docs.docker.com/compose/compose-file/compose-file-v3/#short-syntax-3