### PR TITLE
Refer to ConnectorSyncResult for webhook format

### DIFF
--- a/_docs_integrate/11-connector-configuration.md
+++ b/_docs_integrate/11-connector-configuration.md
@@ -277,3 +277,5 @@ interface RelationshipChange {
     };
 }
 ```
+
+The payload of the webhook is the same as the response payload of the `/api/v1/Account/Sync` endpoint. Thus the type `ConnectorSyncResult` of the [TypeScript SDK](./connector-sdks#typescript-sdk) can be used for specifing the webhook's payload type.


### PR DESCRIPTION
This PR adds a short information that the webhook payload is actually the same as the return type of the `/api/v1/Account/Sync` endpoint (Am I right, that this is the case?). Thus the type `ConnectorSyncResult` can be used to specify the webhook type.

In our organization we first copied the given TypeScript types into our repo (see our file [`enmeshed-payload.ts`](https://github.com/serlo/api.serlo.org/blob/f9c43c5115efe3dd347e5d424d38ae6298a53bad/packages/server/src/internals/server/enmeshed-payload.ts)). Since we already use the TypeScript SDK this is not necessary since we can use `ConnectorSyncResult` directly. This short notice might help others to not do the same :smile: ([feedback#8](https://github.com/nmshd/feedback/issues/8) is still a blocker why we haven't done it yet).