### PR TITLE
Specify that ruby 2.x shall be used

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
+ruby "~> 2"
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the
 # file and run `bundle install`. Run Jekyll with `bundle exec`, like so:


### PR DESCRIPTION
For #26 I created the website locally (it was my first time using ruby / jekyll for a long time :smile: ). However I ran into an error when I executed `bundler install` with ruby version `3.1.0`:

```
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
Fetching gem metadata from https://rubygems.org/.........
nokogiri-1.12.5-x86_64-linux requires ruby version < 3.1.dev, >= 2.5, which is incompatible with the current version,
ruby 3.1.0p0
```

With ruby version `2.7.5` it worked. I guess specifying the ruby version in the Gemfile should help other developers. Maybe the concrete version which you use should be stated in the Gemfile.